### PR TITLE
feat: voiceline template engine — includes and conditionals (#96)

### DIFF
--- a/ed_monitor/voicelines.py
+++ b/ed_monitor/voicelines.py
@@ -23,11 +23,14 @@ Returns None if the key is not found so callers can fall back gracefully.
 """
 from __future__ import annotations
 
+import logging
 import re
 import random
 import tomllib
 from pathlib import Path
 from typing import Optional
+
+_log = logging.getLogger("nova.voicelines")
 
 # Cache: lang → {event_key → [line, ...]}
 _CACHE: dict[str, dict[str, list[str]]] = {}
@@ -147,11 +150,20 @@ def _load(lang: str) -> dict[str, list[str]]:
 def pick(key: str, lang: str = "en", **kwargs) -> Optional[str]:
     """Return a random formatted voiceline for *key* in *lang*, or None.
 
+    Render pipeline (in order):
+      1. _expand_includes — expands {include:_KeyName} / {_KeyName} fragments
+      2. _evaluate_conditionals — replaces WHEN...THEN blocks
+      3. format_map(_SafeDict) — fills {variable} references (missing keys → "")
+
     Fallback logic:
-      - Key in lang map (built-in or user-overridden) → use it; empty list = None.
+      - Key in lang map → use it; empty list → None.
       - Key absent from lang map and lang != "en" → try English built-in.
       - Key absent entirely → None.
+    Fragment keys (starting with '_') are not directly speakable.
     """
+    if key.startswith("_"):
+        return None   # fragment keys are for includes only
+
     lines_map = _load(lang)
 
     if key in lines_map:
@@ -166,9 +178,10 @@ def pick(key: str, lang: str = "en", **kwargs) -> Optional[str]:
 
     template = random.choice(variants)
     try:
-        return template.format(**kwargs)
-    except (KeyError, ValueError):
-        # Return unformatted template rather than crashing
+        template = _expand_includes(template, lines_map, kwargs)
+        template = _evaluate_conditionals(template, kwargs)
+        return template.format_map(_SafeDict(kwargs))
+    except Exception:
         return template
 
 
@@ -210,6 +223,151 @@ def reload_all() -> None:
 
 
 _SUPPORTED_LANGS = ("en", "de", "fr", "it", "es", "pt", "ru")
+
+
+class _SafeDict(dict):
+    """dict subclass that returns '' for missing keys instead of raising KeyError.
+    Used in format_map() so unknown {variables} in user templates don't crash."""
+    def __missing__(self, key: str) -> str:
+        return ""
+
+
+def _eval_clause(clause: str) -> bool:
+    """Evaluate a single condition clause.
+
+    Supported forms:
+      value IS TRUE / IS FALSE / IS NOT TRUE / IS NOT FALSE
+      left == right  |  left != right  |  left < right  |  left > right
+      left <= right  |  left >= right
+    Values are compared numerically when both sides parse as float,
+    otherwise as stripped strings. '' and '0' are falsy for IS TRUE checks.
+    """
+    clause = clause.strip()
+
+    # IS NOT TRUE / IS NOT FALSE
+    m = re.match(r'^(.*?)\s*IS\s+NOT\s+(TRUE|FALSE)\s*$', clause, re.IGNORECASE)
+    if m:
+        val = m.group(1).strip()
+        right = m.group(2).upper()
+        is_truthy = bool(val) and val.upper() not in ("FALSE", "0")
+        return (not is_truthy) if right == "TRUE" else is_truthy
+
+    # IS TRUE / IS FALSE
+    m = re.match(r'^(.*?)\s*IS\s+(TRUE|FALSE)\s*$', clause, re.IGNORECASE)
+    if m:
+        val = m.group(1).strip()
+        right = m.group(2).upper()
+        is_truthy = bool(val) and val.upper() not in ("FALSE", "0")
+        return is_truthy if right == "TRUE" else not is_truthy
+
+    # Comparison operators (==, !=, <=, >=, <, >)
+    m = re.match(r'^(.*?)\s*(==|!=|<=|>=|<|>)\s*(.*)\s*$', clause)
+    if m:
+        left  = m.group(1).strip().strip('"')
+        op    = m.group(2)
+        right = m.group(3).strip().strip('"')
+        try:
+            lf, rf = float(left), float(right)
+            return {
+                "==": lf == rf, "!=": lf != rf,
+                "<":  lf <  rf, ">":  lf >  rf,
+                "<=": lf <= rf, ">=": lf >= rf,
+            }[op]
+        except ValueError:
+            return {
+                "==": left == right, "!=": left != right,
+                "<":  left <  right, ">":  left >  right,
+                "<=": left <= right, ">=": left >= right,
+            }[op]
+
+    # Bare value — truthy check
+    return bool(clause) and clause.upper() not in ("FALSE", "0")
+
+
+# Regex to find {varname} references in a condition string (word chars only)
+_COND_VAR_RE = re.compile(r'\{(\w+)\}')
+
+
+def _eval_condition(condition: str, kwargs: dict) -> bool:
+    """Evaluate a full WHEN condition (may contain AND/OR) against kwargs.
+
+    Variable references {varname} are substituted from kwargs before evaluation.
+    OR has lower precedence than AND: each OR-group is ANDed together.
+    """
+    def _sub(m: re.Match) -> str:
+        return str(kwargs.get(m.group(1), ""))
+
+    cond = _COND_VAR_RE.sub(_sub, condition)
+
+    # Split by OR (lower precedence) — any OR-group being true makes the whole true
+    for or_part in re.split(r'\bOR\b', cond, flags=re.IGNORECASE):
+        # Split by AND — all AND-clauses must be true
+        if all(_eval_clause(c.strip()) for c in re.split(r'\bAND\b', or_part, flags=re.IGNORECASE)):
+            return True
+    return False
+
+
+# Regex to match WHEN ... THEN "..." ; blocks.
+# Group 1: condition text; Group 2: THEN text (supports \" escapes inside)
+_WHEN_RE = re.compile(
+    r'WHEN\s+(.+?)\s+THEN\s+"((?:[^"\\]|\\.)*)"\s*;?',
+    re.DOTALL,
+)
+
+
+def _evaluate_conditionals(template: str, kwargs: dict) -> str:
+    """Replace all WHEN...THEN "text"; blocks with their resolved text or ''.
+
+    The THEN text is returned as-is (with {variable} references intact)
+    so the final format_map() pass can fill them in.
+    """
+    def _replace(m: re.Match) -> str:
+        condition = m.group(1)
+        then_text = m.group(2).replace('\\"', '"')
+        return then_text if _eval_condition(condition, kwargs) else ""
+
+    return _WHEN_RE.sub(_replace, template)
+
+
+# Matches both include syntaxes:
+#   {include:KeyName}  — explicit; matches any key ([\w-]+); non-_ keys are rejected in handler
+#   {_KeyName}         — shorthand; word characters only, must start with _ (\w+)
+# Group 1: explicit key, Group 2: shorthand key
+_INCLUDE_RE = re.compile(r'\{include:([\w-]+)\}|\{(_\w+)\}')
+
+_INCLUDE_MAX_DEPTH = 5
+
+
+def _expand_includes(template: str, lines_map: dict, kwargs: dict, depth: int = 0) -> str:
+    """Expand include fragments in *template*.
+
+    Supports two syntaxes:
+      {include:_KeyName}  — explicit; key may contain hyphens
+      {_KeyName}          — shorthand; word characters only
+
+    Looks up each fragment key in *lines_map*, picks a random line, and
+    substitutes it inline. Recursively expands nested includes.
+
+    Cycle detection: depth > _INCLUDE_MAX_DEPTH → warning + expand to ''.
+    Missing or non-_ keys → warning + expand to ''.
+    """
+    if depth > _INCLUDE_MAX_DEPTH:
+        _log.warning("voicelines: include depth exceeded (circular include?)")
+        return _INCLUDE_RE.sub("", template)
+
+    def _replace(m: re.Match) -> str:
+        key = m.group(1) or m.group(2)   # explicit group 1, shorthand group 2
+        if not key.startswith("_"):
+            _log.warning("voicelines: include key %r has no _ prefix — ignored", key)
+            return ""
+        variants = lines_map.get(key)
+        if not variants:
+            _log.warning("voicelines: include key %r not found", key)
+            return ""
+        fragment = random.choice(variants)
+        return _expand_includes(fragment, lines_map, kwargs, depth + 1)
+
+    return _INCLUDE_RE.sub(_replace, template)
 
 
 def _migrate_old_user_voicelines() -> None:
@@ -303,7 +461,20 @@ def ensure_user_files() -> None:
         "## Finding built-in defaults\n\n"
         "The current default files are copied to the `default/` subfolder here\n"
         "on every NOVA launch — use them as a reference for available keys and formats.\n"
-        "Do **not** edit the files in `default/` directly; they are overwritten each launch.\n"
+        "Do **not** edit the files in `default/` directly; they are overwritten each launch.\n\n"
+        "## Template Engine\n\n"
+        "### Includes\n\n"
+        "Define a reusable fragment (key must start with `_`) in your user file:\n\n"
+        "    [_ship_status]\n"
+        "    add = [\"{ship_name} — hull {hull}, fuel {fuel}.\"]\n\n"
+        "Use `{include:_ship_status}` or shorthand `{_ship_status}` in any line.\n"
+        "Hyphens in key names require the explicit form: `{include:_my-key}`.\n\n"
+        "### Conditionals\n\n"
+        "Inline `WHEN condition THEN \"text\";` blocks in any line:\n\n"
+        "    [Scan_Notable]\n"
+        "    add = ['Scanned {body_short}. WHEN {value_raw} > 500000 THEN \"Worth {value}.\";']\n\n"
+        "Condition true → 'text' included. False → replaced with ''.\n\n"
+        "Supported: `IS TRUE`, `IS FALSE`, `IS NOT TRUE`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `AND`, `OR`\n"
     )
     try:
         readme.write_text(readme_text, encoding="utf-8")

--- a/ed_monitor/voicelines/en.default.toml
+++ b/ed_monitor/voicelines/en.default.toml
@@ -47,6 +47,43 @@
 #           {bio_body_count} {neutron_count} {black_hole_count}
 #           {high_value_count} {notable_summary}
 #           {total_scan_value} {total_scan_value_raw}
+#
+# ── Template Engine Features ──────────────────────────────────────────────────
+#
+# INCLUDES — reusable phrase fragments (define in your user en.toml file)
+#
+#   Fragment key must start with _; it is never spoken directly.
+#
+#     [_ship_status]
+#     add = ["{ship_name} — hull {hull}, fuel {fuel}."]
+#
+#   Two equivalent syntaxes to include it:
+#
+#     [FSDJump]
+#     add = ["Arrived in {system}. {include:_ship_status}"]   # explicit
+#     add = ["Arrived in {system}. {_ship_status}"]           # shorthand
+#
+#   Shorthand {_KeyName} supports letters, digits, underscores only.
+#   Use {include:_key-name} (explicit) for keys that contain hyphens.
+#   Missing keys expand to "". Circular includes capped at depth 5.
+#
+# CONDITIONALS — inline WHEN...THEN blocks
+#
+#   WHEN condition THEN "text"; — the block is replaced with "text" when the
+#   condition is true, or with "" when false. The ; terminator is optional at
+#   end of string.
+#
+#     [Scan_Notable]
+#     add = ['Scanned {body_short}. WHEN {value_raw} > 500000 THEN "Worth {value}."; WHEN {bio_count} > 0 THEN "{bio_count} bio signals.";']
+#
+#   Supported operators:
+#     IS TRUE / IS FALSE / IS NOT TRUE
+#     == != < > <= >=
+#     AND   OR
+#
+#   Truthy: non-empty value that is not "0" or "false" (case-insensitive).
+#   Flag variables ({terra}, {landable}, {first_disc} etc.) are "" when absent,
+#   non-empty when present — so "WHEN {terra} IS TRUE" works naturally.
 
 # ── Startup / Shutdown ────────────────────────────────────────────────────────
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nova-ed-monitor"
-version = "1.34.0"
+version = "1.35.0"
 description = "NOVA — Navigation, Operations, and Vessel Assistance for Elite Dangerous"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/test_voicelines_template.py
+++ b/tests/test_voicelines_template.py
@@ -1,0 +1,288 @@
+"""Tests for the voiceline template engine — includes and conditionals (issue #96)."""
+from __future__ import annotations
+from pathlib import Path
+import pytest
+from ed_monitor.voicelines import _eval_clause, _eval_condition, _expand_includes, _evaluate_conditionals
+
+
+class TestEvalClause:
+    def test_is_true_with_nonempty(self):
+        assert _eval_clause("Terraformable IS TRUE") is True
+
+    def test_is_true_with_empty(self):
+        assert _eval_clause(" IS TRUE") is False
+
+    def test_is_false_with_empty(self):
+        assert _eval_clause(" IS FALSE") is True
+
+    def test_is_false_with_nonempty(self):
+        assert _eval_clause("Landable IS FALSE") is False
+
+    def test_is_not_true_with_nonempty(self):
+        assert _eval_clause("Landable IS NOT TRUE") is False
+
+    def test_is_not_true_with_empty(self):
+        assert _eval_clause(" IS NOT TRUE") is True
+
+    def test_numeric_less_than_true(self):
+        assert _eval_clause("25 < 50") is True
+
+    def test_numeric_less_than_false(self):
+        assert _eval_clause("75 < 50") is False
+
+    def test_numeric_greater_than(self):
+        assert _eval_clause("3 > 0") is True
+
+    def test_numeric_equal(self):
+        assert _eval_clause("100 == 100") is True
+
+    def test_numeric_not_equal(self):
+        assert _eval_clause("50 != 100") is True
+
+    def test_numeric_lte(self):
+        assert _eval_clause("50 <= 50") is True
+
+    def test_numeric_gte(self):
+        assert _eval_clause("75 >= 75") is True
+
+    def test_string_equality_true(self):
+        assert _eval_clause('Industrial == Industrial') is True
+
+    def test_string_equality_false(self):
+        assert _eval_clause('Refinery == Industrial') is False
+
+    def test_string_equality_quoted(self):
+        assert _eval_clause('Refinery == "Refinery"') is True
+
+    def test_string_not_equal(self):
+        assert _eval_clause('Industrial != "Refinery"') is True
+
+    def test_zero_is_falsy_for_is_true(self):
+        assert _eval_clause("0 IS TRUE") is False
+
+    def test_zero_is_truthy_for_is_false(self):
+        assert _eval_clause("0 IS FALSE") is True
+
+
+class TestEvalCondition:
+    def test_and_both_true(self):
+        assert _eval_condition("3 > 0 AND Terraformable IS TRUE", {}) is True
+
+    def test_and_first_false(self):
+        assert _eval_condition("0 > 3 AND Terraformable IS TRUE", {}) is False
+
+    def test_and_second_false(self):
+        assert _eval_condition("3 > 0 AND  IS TRUE", {}) is False
+
+    def test_or_first_true(self):
+        assert _eval_condition("3 > 0 OR  IS TRUE", {}) is True
+
+    def test_or_both_false(self):
+        assert _eval_condition(" IS TRUE OR 0 > 3", {}) is False
+
+    def test_variable_substitution(self):
+        assert _eval_condition("{bio_count} > 0", {"bio_count": "3"}) is True
+
+    def test_variable_substitution_false(self):
+        assert _eval_condition("{bio_count} > 0", {"bio_count": ""}) is False
+
+    def test_is_true_via_var(self):
+        assert _eval_condition("{terra} IS TRUE", {"terra": "Terraformable"}) is True
+
+    def test_is_true_via_empty_var(self):
+        assert _eval_condition("{terra} IS TRUE", {"terra": ""}) is False
+
+    def test_and_with_vars(self):
+        assert _eval_condition(
+            "{bio_count} > 0 AND {first_disc} IS TRUE",
+            {"bio_count": "2", "first_disc": "Undiscovered"},
+        ) is True
+
+    def test_or_with_vars(self):
+        assert _eval_condition(
+            "{terra} IS TRUE OR {landable} IS TRUE",
+            {"terra": "", "landable": "Landable"},
+        ) is True
+
+
+class TestEvaluateConditionals:
+    def test_condition_true_inserts_text(self):
+        result = _evaluate_conditionals(
+            'Hello. WHEN {terra} IS TRUE THEN "Terraformable.";',
+            {"terra": "Terraformable"},
+        )
+        assert result == "Hello. Terraformable."
+
+    def test_condition_false_removes_block(self):
+        result = _evaluate_conditionals(
+            'Hello. WHEN {terra} IS TRUE THEN "Terraformable.";',
+            {"terra": ""},
+        )
+        assert result == "Hello. "
+
+    def test_condition_without_trailing_semicolon(self):
+        result = _evaluate_conditionals(
+            'WHEN {bio_count} > 0 THEN "Bio detected."',
+            {"bio_count": "3"},
+        )
+        assert result == "Bio detected."
+
+    def test_multiple_when_blocks(self):
+        result = _evaluate_conditionals(
+            'X. WHEN {terra} IS TRUE THEN "TF."; WHEN {bio_count} > 0 THEN "Bio.";',
+            {"terra": "Terraformable", "bio_count": "2"},
+        )
+        assert result == "X. TF. Bio."
+
+    def test_multiple_when_one_false(self):
+        result = _evaluate_conditionals(
+            'X. WHEN {terra} IS TRUE THEN "TF."; WHEN {bio_count} > 0 THEN "Bio.";',
+            {"terra": "", "bio_count": "2"},
+        )
+        assert result == "X.  Bio."
+
+    def test_then_text_preserves_var_references(self):
+        # {value} reference in THEN text is preserved for later format pass
+        result = _evaluate_conditionals(
+            'WHEN {value_raw} > 0 THEN "Worth {value}.";',
+            {"value_raw": "500000", "value": "500 thousand"},
+        )
+        assert result == "Worth {value}."
+
+    def test_no_when_blocks_unchanged(self):
+        result = _evaluate_conditionals("Arrived in {system}.", {"system": "Sol"})
+        assert result == "Arrived in {system}."
+
+    def test_empty_string(self):
+        assert _evaluate_conditionals("", {}) == ""
+
+
+class TestExpandIncludes:
+    def test_explicit_include_replaced_with_fragment(self):
+        lines_map = {"_greeting": ["Hello, {commander}."]}
+        result = _expand_includes("{include:_greeting} Arrived.", lines_map, {"commander": "Kernic"})
+        assert result == "Hello, {commander}. Arrived."
+
+    def test_shorthand_include_replaced_with_fragment(self):
+        lines_map = {"_greeting": ["Hello, {commander}."]}
+        result = _expand_includes("{_greeting} Arrived.", lines_map, {})
+        assert result == "Hello, {commander}. Arrived."
+
+    def test_shorthand_and_explicit_equivalent(self):
+        lines_map = {"_frag": ["X"]}
+        assert _expand_includes("{include:_frag}", lines_map, {}) == \
+               _expand_includes("{_frag}", lines_map, {})
+
+    def test_missing_explicit_include_replaced_with_empty(self):
+        result = _expand_includes("{include:_missing} Text.", {}, {})
+        assert result == " Text."
+
+    def test_missing_shorthand_replaced_with_empty(self):
+        result = _expand_includes("{_missing} Text.", {}, {})
+        assert result == " Text."
+
+    def test_no_include_unchanged(self):
+        result = _expand_includes("Arrived in {system}.", {}, {"system": "Sol"})
+        assert result == "Arrived in {system}."
+
+    def test_include_without_underscore_prefix_treated_as_missing(self):
+        # Only _ prefix keys are fragments (explicit syntax)
+        lines_map = {"greeting": ["Hello."]}
+        result = _expand_includes("{include:greeting} Text.", lines_map, {})
+        assert result == " Text."
+
+    def test_circular_include_resolved_as_empty(self):
+        lines_map = {"_loop": ["{include:_loop}"]}
+        result = _expand_includes("{include:_loop}", lines_map, {})
+        assert result == ""
+
+    def test_circular_shorthand_resolved_as_empty(self):
+        lines_map = {"_loop": ["{_loop}"]}
+        result = _expand_includes("{_loop}", lines_map, {})
+        assert result == ""
+
+    def test_nested_include(self):
+        lines_map = {
+            "_b": ["world"],
+            "_a": ["hello {include:_b}"],
+        }
+        result = _expand_includes("{include:_a}", lines_map, {})
+        assert result == "hello world"
+
+    def test_nested_shorthand(self):
+        lines_map = {
+            "_b": ["world"],
+            "_a": ["hello {_b}"],
+        }
+        result = _expand_includes("{_a}", lines_map, {})
+        assert result == "hello world"
+
+    def test_multiple_includes_same_line(self):
+        lines_map = {"_x": ["X"], "_y": ["Y"]}
+        result = _expand_includes("{include:_x} and {_y}", lines_map, {})
+        assert result == "X and Y"
+
+    def test_hyphenated_key_via_explicit_syntax(self):
+        lines_map = {"_my-frag": ["Hyphenated."]}
+        result = _expand_includes("{include:_my-frag}", lines_map, {})
+        assert result == "Hyphenated."
+
+
+class TestPickIntegration:
+    """Integration tests: pick() with includes and conditionals end-to-end."""
+
+    def setup_method(self):
+        import ed_monitor.voicelines as vl
+        vl._CACHE.clear()
+        vl._CONFIG_DIR = Path("/nonexistent_test_dir")
+
+    def teardown_method(self):
+        import ed_monitor.voicelines as vl
+        vl._CACHE.clear()
+        vl._CONFIG_DIR = None
+
+    def test_pick_with_conditional_true(self):
+        import ed_monitor.voicelines as vl
+        vl._CACHE["en"] = {
+            "MyEvent": ['Scanned. WHEN {terra} IS TRUE THEN "Terraformable.";'],
+        }
+        result = vl.pick("MyEvent", lang="en", terra="Terraformable")
+        assert result == "Scanned. Terraformable."
+
+    def test_pick_with_conditional_false(self):
+        import ed_monitor.voicelines as vl
+        vl._CACHE["en"] = {
+            "MyEvent": ['Scanned. WHEN {terra} IS TRUE THEN "Terraformable.";'],
+        }
+        result = vl.pick("MyEvent", lang="en", terra="")
+        assert result == "Scanned. "
+
+    def test_pick_with_include(self):
+        import ed_monitor.voicelines as vl
+        vl._CACHE["en"] = {
+            "_hull_info": ["{hull} hull."],
+            "MyEvent":    ["Status: {include:_hull_info}"],
+        }
+        result = vl.pick("MyEvent", lang="en", hull="80 percent")
+        assert result == "Status: 80 percent hull."
+
+    def test_pick_include_with_variable_in_fragment(self):
+        import ed_monitor.voicelines as vl
+        vl._CACHE["en"] = {
+            "_summary": ["{system} has {bio_count} bio signals."],
+            "FSSAllBodiesFound": ["Scan complete. {include:_summary}"],
+        }
+        result = vl.pick("FSSAllBodiesFound", lang="en", system="Colonia", bio_count="3")
+        assert result == "Scan complete. Colonia has 3 bio signals."
+
+    def test_fragment_keys_not_pickable_directly(self):
+        import ed_monitor.voicelines as vl
+        vl._CACHE["en"] = {"_greeting": ["Hello."]}
+        assert vl.pick("_greeting", lang="en") is None
+
+    def test_pick_unknown_variable_returns_empty_not_crash(self):
+        import ed_monitor.voicelines as vl
+        vl._CACHE["en"] = {"MyEvent": ["Value: {value_mapped}."]}
+        # value_mapped not in kwargs — SafeDict returns ""
+        result = vl.pick("MyEvent", lang="en")
+        assert result == "Value: ."


### PR DESCRIPTION
## Summary

- **Includes** — reusable phrase fragments: define `[_fragment_key]` in your user TOML, then use `{include:_fragment_key}` or shorthand `{_fragment_key}` in any voiceline
- **Conditionals** — inline `WHEN condition THEN "text";` blocks that expand to text when true and `""` when false
- **Safe substitution** — unknown `{variable}` names now expand to `""` instead of leaving the raw template or crashing
- 57 new tests covering all new functions end-to-end; 171 total passing

## Test plan

- [ ] `python3.12 -m pytest tests/ -q` — all 171 tests pass
- [ ] Try a user voiceline with `WHEN {value_raw} > 500000 THEN "Worth {value}.";` — shows for high-value bodies, silent for low-value
- [ ] Try `{_fragment_key}` shorthand — expands fragment correctly
- [ ] Try `{include:_key-with-hyphens}` — explicit form supports hyphens

🤖 Generated with [Claude Code](https://claude.com/claude-code)